### PR TITLE
Add support for polling.

### DIFF
--- a/presto/dbapi.py
+++ b/presto/dbapi.py
@@ -225,6 +225,9 @@ class Cursor(object):
             return self._query.warnings
         return None
 
+    def poll(self):
+        return self._query.poll()
+
     def setinputsizes(self, sizes):
         raise presto.exceptions.NotSupportedError
 
@@ -232,10 +235,8 @@ class Cursor(object):
         raise presto.exceptions.NotSupportedError
 
     def execute(self, operation, params=None):
-        self._query = presto.client.PrestoQuery(self._request, sql=operation)
-        result = self._query.execute()
-        self._iterator = iter(result)
-        return result
+        self._query = presto.client.PrestoQuery(self._request, sql=operation).execute()
+        return self._query
 
     def executemany(self, operation, seq_of_params):
         raise presto.exceptions.NotSupportedError
@@ -250,13 +251,10 @@ class Cursor(object):
         An Error (or subclass) exception is raised if the previous call to
         .execute*() did not produce any result set or no call was issued yet.
         """
-
-        try:
-            return next(self._iterator)
-        except StopIteration:
+        result = self.fetchmany(1)
+        if len(result) != 1:
             return None
-        except presto.exceptions.HttpError as err:
-            raise presto.exceptions.OperationalError(str(err))
+        return result[0]
 
     def fetchmany(self, size=None):
         # type: (Optional[int]) -> List[List[Any]]
@@ -284,16 +282,20 @@ class Cursor(object):
             size = self.arraysize
 
         result = []
+        iterator = iter(self._query)
+
         for _ in range(size):
-            row = self.fetchone()
-            if row is None:
+            try:
+                result.append(next(iterator))
+            except StopIteration:
                 break
-            result.append(row)
+            except prestodb.exceptions.HttpError as err:
+                raise prestodb.exceptions.OperationalError(str(err))
 
         return result
 
     def genall(self):
-        return self._query.result
+        return self._query
 
     def fetchall(self):
         # type: () -> List[List[Any]]


### PR DESCRIPTION
This PR was originally put up against the original prestodb version of this library [https://github.com/prestodb/presto-python-client/pull/90] (which now seems to be defunct?); and adds support for polling the status of presto queries, decoupling it from collection of results (fixing #63 on that repository). This is important especially for long-running queries.

Changes:
- Removed `PrestoResult` and merged its functionality with `PrestoQuery`. Keeping both led to some weird logic loops as each tried to keep the other up to date once polling was added.
- Made `PrestoQuery.fetch` a private method `PrestoQuery._fetch`, since calling it directly leads to the iterator not being in sync.
- Made the `PrestoQuery` object cache the query results, otherwise there is some weird behaviour whereby if you stop iterating over the rows, you throw away all of the rows left over in the last retrieved chunk.
- Switched the `fetchone` / `fetchmany` relationship so that `fetchone` is a special case of `fetchmany` (because the changes above allow multiple iterators to be created over time, so long as there is only one at time, and in this way we don't create a new generator for every row).