### PR TITLE
Developer improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,143 @@
-.idea/
-/dist
-/.venv/
-*.egg-info
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# static files generated from Django application using `collectstatic`
+media
+static

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 services:
   - docker
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,5 @@
 envlist = py27,py35,py36,pypy2
 
 [testenv]
-deps = pytest
-       httpretty
+extras = tests
 commands = pytest -s tests/ integration_tests/

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py27,py35,py36,pypy2
 
 [testenv]
 extras = tests
-commands = pytest -s tests/ integration_tests/
+commands = pytest -sv tests/ integration_tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,pypy2
+envlist = py27,py35,py36,py37,pypy2
 
 [testenv]
 extras = tests


### PR DESCRIPTION
This scratches a few development itches that I encountered while working on the project.

1) The gitignore did not cover the usual things like tox environments. I replaced it with the GitHub template.
2) Pytest was not set up to report verbosely, meaning that when errors occurred it was more difficult to identify exactly which test was failing.

I also added coverage for Python 3.7 (everything passes, so why not?), and set up tox to read the test dependencies from the setup.py configuration (there were some missing dependencies otherwise for local tox runs, such as requests_kerberos).

Feel free to accept or reject any of these "improvements".

