### PR TITLE
Remove default redirect_handler

### DIFF
--- a/presto/client.py
+++ b/presto/client.py
@@ -205,7 +205,7 @@ class PrestoRequest(object):
         transaction_id=NO_TRANSACTION,  # type: Optional[Text]
         http_scheme=constants.HTTP,  # type: Text
         auth=constants.DEFAULT_AUTH,  # type: Optional[Any]
-        redirect_handler=presto.redirect.GatewayRedirectHandler(),
+        redirect_handler=None,
         max_attempts=MAX_ATTEMPTS,  # type: int
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,  # type: Union[float, Tuple[float, float]]
         handle_retry=exceptions.RetryWithExponentialBackoff(),

--- a/presto/dbapi.py
+++ b/presto/dbapi.py
@@ -71,7 +71,7 @@ class Connection(object):
         http_headers=None,
         http_scheme=constants.HTTP,
         auth=constants.DEFAULT_AUTH,
-        redirect_handler=presto.redirect.GatewayRedirectHandler(),
+        redirect_handler=None,
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
         isolation_level=IsolationLevel.AUTOCOMMIT,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,6 +24,7 @@ from presto.client import PrestoRequest
 from presto.auth import KerberosAuthentication
 from presto import constants
 import presto.exceptions
+import presto.redirect
 
 
 """
@@ -576,7 +577,7 @@ def test_gateway_redirect(monkeypatch):
         socket, "gethostbyaddr", lambda *args: ("finalhost", ["finalhost"], "1.2.3.4")
     )
 
-    req = PrestoRequest(host="coordinator", port=8080, user="test")
+    req = PrestoRequest(host="coordinator", port=8080, user="test", redirect_handler=presto.redirect.GatewayRedirectHandler())
     result = req.post("http://host:80/path/")
     assert gateway_response.count == 3
     assert result.ok


### PR DESCRIPTION
Let the HTTP session handler the redirects with `allow_redirects=True`
by default.

Fixes https://github.com/prestosql/presto-python-client/issues/17