### PR TITLE
Expose verify parameter on dbapi.connect

### DIFF
--- a/presto/client.py
+++ b/presto/client.py
@@ -209,6 +209,7 @@ class PrestoRequest(object):
         max_attempts=MAX_ATTEMPTS,  # type: int
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,  # type: Union[float, Tuple[float, float]]
         handle_retry=exceptions.RetryWithExponentialBackoff(),
+        verify=True     # type: Any
     ):
         # type: (...) -> None
         self._client_session = ClientSession(
@@ -230,6 +231,7 @@ class PrestoRequest(object):
         else:
             # mypy cannot follow module import
             self._http_session = self.http.Session()  # type: ignore
+            self._http_session.verify = verify
         self._http_session.headers.update(self.http_headers)
         self._exceptions = self.HTTP_EXCEPTIONS
         self._auth = auth

--- a/presto/dbapi.py
+++ b/presto/dbapi.py
@@ -75,6 +75,7 @@ class Connection(object):
         max_attempts=constants.DEFAULT_MAX_ATTEMPTS,
         request_timeout=constants.DEFAULT_REQUEST_TIMEOUT,
         isolation_level=IsolationLevel.AUTOCOMMIT,
+        verify=True
     ):
         self.host = host
         self.port = port
@@ -85,6 +86,7 @@ class Connection(object):
         self.session_properties = session_properties
         # mypy cannot follow module import
         self._http_session = presto.client.PrestoRequest.http.Session()
+        self._http_session.verify = verify
         self.http_headers = http_headers
         self.http_scheme = http_scheme
         self.auth = auth


### PR DESCRIPTION
This PR exposes the verify parameter to explicitly specify client certificate path.

This resolves #29