### PR TITLE
Support self-signed SSL certificates

### DIFF
--- a/presto/auth.py
+++ b/presto/auth.py
@@ -85,7 +85,7 @@ class KerberosAuthentication(Authentication):
             delegate=self._delegate,
             service=self._service_name,
         )
-        if self._ca_bundle:
+        if self._ca_bundle is not None:
             http_session.verify = self._ca_bundle
         return http_session
 


### PR DESCRIPTION
Hello,

I would like to add support for self-signed SSL certificates. Requests can ignore verifying the SSL certificate if we set verify to False: Unfortunately, this is not possible in this library. Unfortunately, in this library it is not possible due to one incorrect condition in if-statement.
https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification
This is what I need to work on integration testing for Kerberos + Presto. I currently have a prepared environment.
https://github.com/mik-laj/presto-kerberos-docker
In the next step, I would like to integrate it with [Apache Airflow](https://github.com/apache/airflow).

**Question for the project maintainer:**
Would you like to use this environment in your CI/CD as well to test authorizations with Kerberos? Currently, they are very easy to configure. Just call ``start.sh`` and a full environment in Docker will be set up.

Best regards,
Kamil

