### PR TITLE
Add .idea directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# IDEA project settings
+.idea/
+
 # mkdocs documentation
 /site
 


### PR DESCRIPTION
It seems `.idea/` was accidentally removed in https://github.com/prestosql/presto-python-client/commit/392f6439b56ea3f128c54458429f1bd510a6bee4.