### PR TITLE
Fix referenced before assignment error in execute

### DIFF
--- a/integration_tests/test_dbapi.py
+++ b/integration_tests/test_dbapi.py
@@ -15,6 +15,10 @@ import fixtures
 import presto
 import pytest
 from fixtures import run_presto
+import pytest
+
+import presto
+from presto.exceptions import PrestoQueryError
 from presto.transaction import IsolationLevel
 
 
@@ -233,3 +237,16 @@ def test_transaction_multiple(presto_connection_with_transaction):
 
     assert len(rows1) == 1000
     assert len(rows2) == 1000
+
+def test_invalid_query_throws_correct_error(presto_connection):
+    """
+    tests that an invalid query raises the correct exception
+    """
+    cur = presto_connection.cursor()
+    with pytest.raises(PrestoQueryError):
+        cur.execute(
+            """
+            select * FRMO foo WHERE x = ?; 
+            """,
+            params=(3,),
+        )

--- a/presto/dbapi.py
+++ b/presto/dbapi.py
@@ -325,13 +325,12 @@ class Cursor(object):
             )
 
             statement_name = self._generate_unique_statement_name()
+            # Send prepare statement
+            added_prepare_header = self._prepare_statement(
+                operation, statement_name
+            )
 
             try:
-                # Send prepare statement
-                added_prepare_header = self._prepare_statement(
-                    operation, statement_name
-                )
-
                 # Send execute statement and assign the return value to `results`
                 # as it will be returned by the function
                 self._query = self._get_added_prepare_statement_presto_query(


### PR DESCRIPTION
Fixes a runtime error with added_prepare_header variable not being
present when an exception happens during creation of a prepared
statement.