### PR TITLE
Fix use of string parameters in prepared statements

### DIFF
--- a/integration_tests/test_dbapi.py
+++ b/integration_tests/test_dbapi.py
@@ -12,8 +12,6 @@
 from __future__ import absolute_import, division, print_function
 
 import fixtures
-import presto
-import pytest
 from fixtures import run_presto
 import pytest
 
@@ -89,12 +87,22 @@ def test_select_query_result_iteration_statement_params(presto_connection):
         params=(3,)  # expecting all the rows with id >= 3
     )
 
-    rows = cur.fetchall()
-    assert len(rows) == 3
+def test_select_query_result_string_statement_params(presto_connection):
+    """
+    Tests string parameters in prepared statements
+    """
+    cur = presto_connection.cursor()
+    # test a simple string parameter and
+    # a parameter with a quote in it
+    cur.execute(
+        "select ?",
+        params=("six'",),
+    )
 
-    for row in rows:
-        # Validate that all the ids of the returned rows are greather or equals than 3
-        assert row[0] >= 3
+    rows = cur.fetchall()
+
+    assert len(rows) == 1
+    assert rows[0][0] == "six'"
 
 
 @pytest.mark.parametrize('params', [


### PR DESCRIPTION
Prior to this commit parameters passed to execute were added to the
EXECUTE statement as naked strings. When using strings this causes a
syntax error in the query because Presto thinks it's a constant.
Example:
```
EXECUTE "st-XXX" USING Bob
```
results in:
```
Query 20201014_232548_02077_8sytd failed: line 1:22: Constant expression cannot contain column references
```
In this commit, string parameters passed to the execute are single
quoted to form a proper query. Care has been taken to escape single
quotes to avoid other query syntax errors and SQL injection.