### PR TITLE
 Handle python types for query parameters

### DIFF
--- a/integration_tests/fixtures.py
+++ b/integration_tests/fixtures.py
@@ -29,7 +29,7 @@ from presto.exceptions import TimeoutError
 logger = presto.logging.get_logger(__name__)
 
 
-PRESTO_VERSION = os.environ.get("PRESTO_VERSION") or "329"
+PRESTO_VERSION = os.environ.get("PRESTO_VERSION") or "344"
 PRESTO_HOST = "127.0.0.1"
 PRESTO_PORT = 8080
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ kerberos_require = ["requests_kerberos"]
 
 all_require = [kerberos_require]
 
-tests_require = all_require + ["httpretty", "pytest", "pytest-runner", "mock"]
+tests_require = all_require + ["httpretty", "pytest", "pytest-runner", "mock", "pytz"]
 
 py27_require = ["ipaddress", "typing"]
 


### PR DESCRIPTION
Prior to this commit, the only python types supported as query parameters were str and int. In this commit the types are expanded to bool, float, bytes, datetime, list, dict, and UUID.