### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ with presto.dbapi.connect(
 ) as conn:
   cur = conn.cursor()
   cur.execute('INSERT INTO sometable VALUES (1, 2, 3)')
+  cur.fetchone()
   cur.execute('INSERT INTO sometable VALUES (4, 5, 6)')
+  cur.fetchone()
 ```
 
 The transaction is created when the first SQL statement is executed.


### PR DESCRIPTION
The explicit `fetchall()` call is needed since
https://github.com/prestosql/presto/commit/568449b8d058ed8281cc5277bb53902fd044cad7.
Of course, it was strongly recommended even before that, as otherwise
invoking application did not know whether query succeeded, failed or was
considered abandoned.

Relates to: https://github.com/prestosql/presto-python-client/issues/56